### PR TITLE
fix: remove security parameter d from decrypt and verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ let mut msg = Message::new(get_random_bytes(5242880));
 // Encrypt the data with 256 bits of security
 msg.pw_encrypt(&pw, 512);
 // Decrypt the data
-msg.pw_decrypt(&pw, 512);
+msg.pw_decrypt(&pw);
 // Verify operation success
 assert!(msg.op_result.unwrap());
 ```
@@ -80,7 +80,7 @@ let key_pair = KeyPair::new(&get_random_bytes(32), "test key".to_string(), E448,
 // Encrypt the message
 msg.key_encrypt(&key_pair.pub_key, 512);
 // Decrypt the message
-msg.key_decrypt(&key_pair.priv_key, 512);
+msg.key_decrypt(&key_pair.priv_key);
 // Verify
 assert!(msg.op_result.unwrap());
 ```
@@ -102,7 +102,7 @@ let key_pair = KeyPair::new(&pw, "test key".to_string(), E448, 512);
 // Sign with 256 bits of security
 msg.sign(&key_pair, 512);
 // Verify signature
-msg.verify(&key_pair.pub_key, 512);
+msg.verify(&key_pair.pub_key);
 // Assert correctness
 assert!(msg.op_result.unwrap());
 ```

--- a/benches/benchmark_e222_224.rs
+++ b/benches/benchmark_e222_224.rs
@@ -12,20 +12,20 @@ const BIT_SECURITY: u64 = 224;
 /// Symmetric encrypt and decrypt roundtrip
 fn sym_enc(pw: &mut Vec<u8>, mut msg: Message) {
     msg.pw_encrypt(&pw, BIT_SECURITY);
-    msg.pw_decrypt(&pw, BIT_SECURITY);
+    msg.pw_decrypt(&pw);
 }
 
 /// Asymmetric encrypt and decrypt roundtrip + keygen
 fn key_gen_enc_dec(pw: &mut Vec<u8>, mut msg: Message) {
     let key_pair = KeyPair::new(pw, "test key".to_string(), SELECTED_CURVE, BIT_SECURITY);
     msg.key_encrypt(&key_pair.pub_key, BIT_SECURITY);
-    msg.key_decrypt(&key_pair.priv_key, BIT_SECURITY);
+    msg.key_decrypt(&key_pair.priv_key);
 }
 
 /// Signature generation + verification roundtrip
 pub fn sign_verify(mut key_pair: KeyPair, mut msg: Message) {
     msg.sign(&mut key_pair, BIT_SECURITY);
-    msg.verify(&key_pair.pub_key, BIT_SECURITY);
+    msg.verify(&key_pair.pub_key);
 }
 
 fn bench_sign_verify(c: &mut Criterion) {

--- a/benches/benchmark_e521_512.rs
+++ b/benches/benchmark_e521_512.rs
@@ -12,20 +12,20 @@ const BIT_SECURITY: u64 = 512;
 /// Symmetric encrypt and decrypt roundtrip
 fn sym_enc(pw: &mut Vec<u8>, mut msg: Message) {
     msg.pw_encrypt(&pw, BIT_SECURITY);
-    msg.pw_decrypt(&pw, BIT_SECURITY);
+    msg.pw_decrypt(&pw);
 }
 
 /// Asymmetric encrypt and decrypt roundtrip + keygen
 fn key_gen_enc_dec(pw: &mut Vec<u8>, mut msg: Message) {
     let key_pair = KeyPair::new(pw, "test key".to_string(), SELECTED_CURVE, BIT_SECURITY);
     msg.key_encrypt(&key_pair.pub_key, BIT_SECURITY);
-    msg.key_decrypt(&key_pair.priv_key, BIT_SECURITY);
+    msg.key_decrypt(&key_pair.priv_key);
 }
 
 /// Signature generation + verification roundtrip
 pub fn sign_verify(mut key_pair: KeyPair, mut msg: Message) {
     msg.sign(&mut key_pair, BIT_SECURITY);
-    msg.verify(&key_pair.pub_key, BIT_SECURITY);
+    msg.verify(&key_pair.pub_key);
 }
 
 fn bench_sign_verify(c: &mut Criterion) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ impl Message {
     pub fn new(data: Vec<u8>) -> Message {
         Message {
             msg: Box::new(data),
+            d: None,
             sym_nonce: None,
             asym_nonce: None,
             digest: None,
@@ -63,6 +64,7 @@ impl Message {
 /// Message type for which cryptographic traits are defined.
 pub struct Message {
     pub msg: Box<Vec<u8>>,
+    pub d: Option<u64>,
     pub sym_nonce: Option<Vec<u8>>,
     pub asym_nonce: Option<EdCurvePoint>,
     pub digest: Option<Vec<u8>>,
@@ -77,15 +79,15 @@ pub trait Hashable {
 
 pub trait PwEncryptable {
     fn pw_encrypt(&mut self, pw: &[u8], d: u64);
-    fn pw_decrypt(&mut self, pw: &[u8], d: u64);
+    fn pw_decrypt(&mut self, pw: &[u8]);
 }
 
 pub trait KeyEncryptable {
     fn key_encrypt(&mut self, pub_key: &EdCurvePoint, d: u64);
-    fn key_decrypt(&mut self, pw: &[u8], d: u64);
+    fn key_decrypt(&mut self, pw: &[u8]);
 }
 
 pub trait Signable {
     fn sign(&mut self, key: &KeyPair, d: u64);
-    fn verify(&mut self, pub_key: &EdCurvePoint, d: u64);
+    fn verify(&mut self, pub_key: &EdCurvePoint);
 }

--- a/tests/ops_tests.rs
+++ b/tests/ops_tests.rs
@@ -12,7 +12,7 @@ pub mod ops_tests {
         let mut msg = Message::new(get_random_bytes(5242880));
 
         msg.pw_encrypt(&pw, 256);
-        msg.pw_decrypt(&pw, 256);
+        msg.pw_decrypt(&pw);
 
         assert!(msg.op_result.unwrap());
     }
@@ -22,7 +22,7 @@ pub mod ops_tests {
         let mut msg = Message::new(get_random_bytes(5242880));
 
         msg.pw_encrypt(&pw, 256);
-        msg.pw_decrypt(&pw, 256);
+        msg.pw_decrypt(&pw);
 
         assert!(msg.op_result.unwrap());
     }
@@ -32,7 +32,7 @@ pub mod ops_tests {
         let key_pair = KeyPair::new(&get_random_bytes(32), "test key".to_string(), E448, 256);
 
         msg.key_encrypt(&key_pair.pub_key, 256);
-        msg.key_decrypt(&key_pair.priv_key, 256);
+        msg.key_decrypt(&key_pair.priv_key);
 
         assert!(msg.op_result.unwrap());
     }
@@ -43,7 +43,7 @@ pub mod ops_tests {
         let key_pair = KeyPair::new(&get_random_bytes(32), "test key".to_string(), E448, 512);
 
         msg.key_encrypt(&key_pair.pub_key, 512);
-        msg.key_decrypt(&key_pair.priv_key, 512);
+        msg.key_decrypt(&key_pair.priv_key);
 
         assert!(msg.op_result.unwrap());
     }
@@ -54,7 +54,7 @@ pub mod ops_tests {
         let key_pair = KeyPair::new(&pw, "test key".to_string(), E448, 512);
 
         msg.sign(&key_pair, 512);
-        msg.verify(&key_pair.pub_key, 512);
+        msg.verify(&key_pair.pub_key);
 
         assert!(msg.op_result.unwrap());
     }
@@ -68,7 +68,7 @@ pub mod ops_tests {
             let now = Instant::now();
             msg.sign(&mut key_pair, 512);
             println!("{} needed {} microseconds", i, now.elapsed().as_micros());
-            msg.verify(&key_pair.pub_key, 512);
+            msg.verify(&key_pair.pub_key);
             assert!(msg.op_result.unwrap());
         }
     }


### PR DESCRIPTION
assumes that any message type is well-formed and removes d from calls to decrypt in symmetric and asymmetric operations as well as signature verification.