### PR TITLE
Feature/issue 21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -102,6 +102,7 @@ dependencies = [
  "num-bigint",
  "rand",
  "rayon",
+ "serde",
  "structopt",
  "tiny_ed448_goldilocks",
 ]
@@ -114,9 +115,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
 
 [[package]]
 name = "cfg-if"
@@ -281,51 +282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
-
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -625,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -817,17 +773,6 @@ dependencies = [
 [[package]]
 name = "syn"
 version = "2.0.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -702,7 +702,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -743,7 +743,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -751,6 +751,17 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -866,7 +877,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -888,7 +899,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +81,7 @@ dependencies = [
  "num-bigint",
  "rand",
  "rayon",
+ "structopt",
  "tiny_ed448_goldilocks",
 ]
 
@@ -124,9 +134,13 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
+ "ansi_term",
+ "atty",
  "bitflags",
+ "strsim",
  "textwrap",
  "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -356,6 +370,15 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -617,6 +640,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +814,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,10 +927,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tiny_ed448_goldilocks = "0.1.7"
 aes = "0.8.3"
 rayon = "1.5"
 structopt = "0.3"
+serde = { version = "1.0", features = ["derive"] }
 
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ num-bigint = { version = "0.4", features = ["rand"] }
 tiny_ed448_goldilocks = "0.1.3"
 aes = "0.8.3"
 rayon = "1.5"
+structopt = "0.3"
 
 
 [[bench]]

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,0 +1,32 @@
+use structopt::StructOpt;
+use capycrypt::{Hashable, Message, SecParam};
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "capycrypt-cli", about = "A simple hashing CLI")]
+enum Command {       //enums and structs in rust can be used almost interchangeably.
+    #[structopt(name = "compute_sha3_hash")]   // the name of the program to run
+    Sha3 {
+        #[structopt(help = "The input string to hash")]
+        input: String,
+
+        #[structopt(help = "Number of bits for the SHA3 hash", short, long, default_value = "256")]
+        bits: usize,
+    },
+}
+
+fn main() {
+    match Command::from_args() {
+        Command::Sha3 { input, bits } => {
+            let mut data = Message::new(input.into_bytes());
+            let sec_param = SecParam::from_int(bits)
+                .expect("Unsupported security parameter. Use 224, 256, 384, or 512");
+            
+            data.compute_hash_sha3(&sec_param).expect("An error occurred during hash computation.");
+            
+            match data.digest {
+                Ok(digest) => println!("Hash: {}", hex::encode(digest.to_vec())),
+                Err(_) => eprintln!("Error: Hash computation failed"),
+            }
+        }
+    }
+}

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,15 +1,21 @@
-use structopt::StructOpt;
 use capycrypt::{Hashable, Message, SecParam};
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "capycrypt-cli", about = "A simple hashing CLI")]
-enum Command {       //enums and structs in rust can be used almost interchangeably.
-    #[structopt(name = "compute_sha3_hash")]   // the name of the program to run
+enum Command {
+    //enums and structs in rust can be used almost interchangeably.
+    #[structopt(name = "compute_sha3_hash")] // the name of the program to run
     Sha3 {
         #[structopt(help = "The input string to hash")]
         input: String,
 
-        #[structopt(help = "Number of bits for the SHA3 hash", short, long, default_value = "256")]
+        #[structopt(
+            help = "Number of bits for the SHA3 hash",
+            short,
+            long,
+            default_value = "256"
+        )]
         bits: usize,
     },
 }
@@ -20,11 +26,12 @@ fn main() {
             let mut data = Message::new(input.into_bytes());
             let sec_param = SecParam::from_int(bits)
                 .expect("Unsupported security parameter. Use 224, 256, 384, or 512");
-            
-            data.compute_hash_sha3(&sec_param).expect("An error occurred during hash computation.");
-            
+
+            data.compute_hash_sha3(&sec_param)
+                .expect("An error occurred during hash computation.");
+
             match data.digest {
-                Ok(digest) => println!("Hash: {}", hex::encode(digest.to_vec())),
+                Ok(digest) => println!("Hash: {}", hex::encode(digest)),
                 Err(_) => eprintln!("Error: Hash computation failed"),
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ impl Message {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 /// An enum representing standard digest lengths based on FIPS PUB 202
 pub enum SecParam {
     /// Digest length of 224 bits, also known as SHA3-224
@@ -114,6 +114,39 @@ pub enum SecParam {
 }
 
 impl SecParam {
+
+    /// Convert an integer input to the corresponding security parameter.
+    /// # Arguments
+    ///
+    /// * `value` - An integer representing the desired security parameter.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(SecParam)` - If the conversion is successful, returns the corresponding `SecParam`.
+    /// * `Err(OperationError)` - If the given `value` does not correspond to any supported security parameter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use capycrypt::SecParam;
+    /// use capycrypt::OperationError;
+    ///
+    /// assert_eq!(SecParam::from_int(224).unwrap(), SecParam::D224);
+    /// assert_eq!(SecParam::from_int(256).unwrap(), SecParam::D256);
+    /// assert_eq!(SecParam::from_int(384).unwrap(), SecParam::D384);
+    /// assert_eq!(SecParam::from_int(512).unwrap(), SecParam::D512);
+    /// assert_eq!(SecParam::from_int(1024), Err(OperationError::UnsupportedSecurityParameter))
+    /// ``` 
+    pub fn from_int(value: usize) -> Result<SecParam, OperationError> {
+        match value {
+            224 => Ok(SecParam::D224),
+            256 => Ok(SecParam::D256),
+            384 => Ok(SecParam::D384),
+            512 => Ok(SecParam::D512),
+            _ => Err(OperationError::UnsupportedSecurityParameter),
+        }
+    }
+
     fn bytepad_value(&self) -> u32 {
         match self {
             SecParam::D224 => 172,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,6 @@ pub enum SecParam {
 }
 
 impl SecParam {
-
     /// Convert an integer input to the corresponding security parameter.
     /// # Arguments
     ///
@@ -136,7 +135,7 @@ impl SecParam {
     /// assert_eq!(SecParam::from_int(384).unwrap(), SecParam::D384);
     /// assert_eq!(SecParam::from_int(512).unwrap(), SecParam::D512);
     /// assert_eq!(SecParam::from_int(1024), Err(OperationError::UnsupportedSecurityParameter))
-    /// ``` 
+    /// ```
     pub fn from_int(value: usize) -> Result<SecParam, OperationError> {
         match value {
             224 => Ok(SecParam::D224),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,12 @@ use capycrypt::{Hashable, Message, SecParam};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "capycrypt-cli", about = "A simple hashing CLI")]
+#[structopt(
+    name = "capycrypt-cli",
+    about = "Support command-line interface for capyCrypt library"
+)]
 enum Command {
-    //enums and structs in rust can be used almost interchangeably.
-    #[structopt(name = "compute_sha3_hash")] // the name of the program to run
+    #[structopt(name = "sha3")]
     Sha3 {
         #[structopt(help = "The input string to hash")]
         input: String,


### PR DESCRIPTION
This pull request implements a command-line interface (CLI) for the SHA-3 hash function.
To use this feature, users can follow these steps:
1. Run `cargo install --path .`
After installation, users can execute the following command:
2. capycrypt sha3 "msg" -b security_bit

Replace "msg" with the message to be hashed and security_bit with the desired security level in bits."

