### PR TITLE
Feature/issue 16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -102,6 +102,7 @@ dependencies = [
  "num-bigint",
  "rand",
  "rayon",
+ "serde",
  "structopt",
  "tiny_ed448_goldilocks",
 ]
@@ -114,9 +115,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
 
 [[package]]
 name = "cfg-if"
@@ -281,51 +282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
-
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -625,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -817,17 +773,6 @@ dependencies = [
 [[package]]
 name = "syn"
 version = "2.0.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,9 +129,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"
@@ -135,9 +141,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -255,6 +261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "rand_core",
+ "serdect",
  "subtle",
 ]
 
@@ -291,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "errno"
@@ -307,15 +314,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
 
 [[package]]
 name = "generic-array"
@@ -432,9 +439,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "linux-raw-sys"
@@ -456,9 +463,9 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "num"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+checksum = "3135b08af27d103b0a51f2ae0f8632117b7b185ccf931445affa8df530576a41"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -602,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -699,9 +706,9 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -727,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
@@ -746,23 +753,33 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 
@@ -815,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -847,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "tiny_ed448_goldilocks"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f221a42eca71648c41ba609ffae808d1331c6c0d73702243c7f80c1a58cb63a"
+checksum = "7ed7e1352d8be1a15905b6cb34ea14de90a9a256714a1525f4699875d089dbac"
 dependencies = [
  "base64",
  "crypto-bigint",
@@ -889,9 +906,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "vec_map"
@@ -942,7 +959,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -964,7 +981,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1003,11 +1020,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1036,13 +1053,14 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -1051,42 +1069,48 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
+ "serde_json",
  "structopt",
  "tiny_ed448_goldilocks",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -702,7 +702,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -743,7 +743,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -751,6 +751,17 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -866,7 +877,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -888,7 +899,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +111,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "tempfile",
  "tiny_ed448_goldilocks",
 ]
 
@@ -158,7 +165,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -289,6 +296,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +435,12 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "log"
@@ -669,6 +698,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "rustix"
+version = "0.38.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+dependencies = [
+ "bitflags 2.5.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +822,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -967,6 +1021,15 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +81,7 @@ dependencies = [
  "num-bigint",
  "rand",
  "rayon",
+ "structopt",
  "tiny_ed448_goldilocks",
 ]
 
@@ -124,9 +134,13 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
+ "ansi_term",
+ "atty",
  "bitflags",
+ "strsim",
  "textwrap",
  "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -356,6 +370,15 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -617,6 +640,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +814,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,10 +927,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ aes = "0.8.3"
 rayon = "1.5"
 structopt = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-
+serde_json = "1.0"
 
 [[bench]]
 name = "benchmark_sha3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ hex = {version = "0.4.3"}
 byteorder = {version = "1.4.3"}
 chrono = {version = "0.4.23"}
 criterion = "0.3"
-crypto-bigint = "0.5.3"
+crypto-bigint = {version = "0.5.3", features = ["serde", "alloc"]}
 fiat-crypto = "0.2.2"
 rand = "0.8"
 num-bigint = { version = "0.4", features = ["rand"] }
-tiny_ed448_goldilocks = "0.1.7"
+tiny_ed448_goldilocks = { version = "0.1.8"}
 aes = "0.8.3"
 rayon = "1.5"
 structopt = "0.3"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["alloc", "derive"] }
 serde_json = "1.0"
 tempfile = "3.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ rayon = "1.5"
 structopt = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tempfile = "3.2"
 
 [[bench]]
 name = "benchmark_sha3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tiny_ed448_goldilocks = "0.1.7"
 aes = "0.8.3"
 rayon = "1.5"
 structopt = "0.3"
+serde = { version = "1.0", features = ["derive"] }
 
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ num-bigint = { version = "0.4", features = ["rand"] }
 tiny_ed448_goldilocks = "0.1.3"
 aes = "0.8.3"
 rayon = "1.5"
+structopt = "0.3"
 
 
 [[bench]]

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,0 +1,32 @@
+use structopt::StructOpt;
+use capycrypt::{Hashable, Message, SecParam};
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "capycrypt-cli", about = "A simple hashing CLI")]
+enum Command {       //enums and structs in rust can be used almost interchangeably.
+    #[structopt(name = "compute_sha3_hash")]   // the name of the program to run
+    Sha3 {
+        #[structopt(help = "The input string to hash")]
+        input: String,
+
+        #[structopt(help = "Number of bits for the SHA3 hash", short, long, default_value = "256")]
+        bits: usize,
+    },
+}
+
+fn main() {
+    match Command::from_args() {
+        Command::Sha3 { input, bits } => {
+            let mut data = Message::new(input.into_bytes());
+            let sec_param = SecParam::from_int(bits)
+                .expect("Unsupported security parameter. Use 224, 256, 384, or 512");
+            
+            data.compute_hash_sha3(&sec_param).expect("An error occurred during hash computation.");
+            
+            match data.digest {
+                Ok(digest) => println!("Hash: {}", hex::encode(digest.to_vec())),
+                Err(_) => eprintln!("Error: Hash computation failed"),
+            }
+        }
+    }
+}

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,15 +1,21 @@
-use structopt::StructOpt;
 use capycrypt::{Hashable, Message, SecParam};
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "capycrypt-cli", about = "A simple hashing CLI")]
-enum Command {       //enums and structs in rust can be used almost interchangeably.
-    #[structopt(name = "compute_sha3_hash")]   // the name of the program to run
+enum Command {
+    //enums and structs in rust can be used almost interchangeably.
+    #[structopt(name = "compute_sha3_hash")] // the name of the program to run
     Sha3 {
         #[structopt(help = "The input string to hash")]
         input: String,
 
-        #[structopt(help = "Number of bits for the SHA3 hash", short, long, default_value = "256")]
+        #[structopt(
+            help = "Number of bits for the SHA3 hash",
+            short,
+            long,
+            default_value = "256"
+        )]
         bits: usize,
     },
 }
@@ -20,11 +26,12 @@ fn main() {
             let mut data = Message::new(input.into_bytes());
             let sec_param = SecParam::from_int(bits)
                 .expect("Unsupported security parameter. Use 224, 256, 384, or 512");
-            
-            data.compute_hash_sha3(&sec_param).expect("An error occurred during hash computation.");
-            
+
+            data.compute_hash_sha3(&sec_param)
+                .expect("An error occurred during hash computation.");
+
             match data.digest {
-                Ok(digest) => println!("Hash: {}", hex::encode(digest.to_vec())),
+                Ok(digest) => println!("Hash: {}", hex::encode(digest)),
                 Err(_) => eprintln!("Error: Hash computation failed"),
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub mod aes {
 /// Module for encrypt, decrypt, and sign functions.
 pub mod ops;
 
-#[derive(Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 /// A simple error type
 pub enum OperationError {
     UnsupportedSecurityParameter,
@@ -47,7 +47,7 @@ pub enum OperationError {
     AESCTRDecryptionFailure,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 /// An object containing the necessary fields for Schnorr signatures.
 pub struct Signature {
     /// keyed hash of signed message
@@ -69,7 +69,7 @@ pub struct KeyPair {
     pub date_created: String,
 }
 
-#[derive(Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 /// Message struct for which cryptographic traits are defined.
 pub struct Message {
     /// Input message
@@ -88,22 +88,7 @@ pub struct Message {
     pub sig: Option<Signature>,
 }
 
-impl Message {
-    /// Returns a new Message instance
-    pub fn new(data: Vec<u8>) -> Message {
-        Message {
-            msg: Box::new(data),
-            d: None,
-            sym_nonce: None,
-            asym_nonce: None,
-            digest: Ok(vec![]),
-            op_result: Ok(()),
-            sig: None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 /// An enum representing standard digest lengths based on FIPS PUB 202
 pub enum SecParam {
     /// Digest length of 224 bits, also known as SHA3-224

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![warn(clippy::just_underscores_and_digits)]
+use ops::kmac_xof;
+use sha3::aux_functions::byte_utils::{bytes_to_scalar, get_date_and_time_as_string};
 /// Elliptic curve backend
 use tiny_ed448_goldilocks::curve::{extended_edwards::ExtendedPoint, field::scalar::Scalar};
 
@@ -25,6 +27,9 @@ pub mod aes {
 
 /// Module for encrypt, decrypt, and sign functions.
 pub mod ops;
+
+use std::fs::File;
+use std::io::Read;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 /// A simple error type
@@ -69,6 +74,109 @@ pub struct KeyPair {
     pub date_created: String,
 }
 
+impl KeyPair {
+    /// # Asymmetric [`KeyPair`] Generation
+    /// Generates a (Schnorr/ECDHIES) key pair from passphrase pw.
+    ///
+    /// ## Algorithm:
+    /// * s ← kmac_xof(pw, “”, 448, “K”); s ← 4s
+    /// * 𝑉 ← s*𝑮
+    /// * key pair: (s, 𝑉)
+    /// ## Arguments:
+    /// * pw: &Vec<u8> : password as bytes, can be blank but shouldnt be
+    /// * owner: String : A label to indicate the owner of the key
+    /// * curve: [`EdCurves`] : The selected Edwards curve
+    /// ## Returns:
+    /// * return  -> [`KeyPair`]: Key object containing owner, private key, public key x and y coordinates, and timestamp.
+    /// verification key 𝑉 is hashed together with the message 𝑚
+    /// and the nonce 𝑈: hash (𝑚, 𝑈, 𝑉) .
+    /// ## Usage:
+    /// ```
+    /// use capycrypt::{
+    ///     KeyEncryptable,
+    ///     KeyPair,
+    ///     Message,
+    ///     sha3::aux_functions::byte_utils::get_random_bytes,
+    ///     SecParam,
+    /// };
+    ///
+    /// // Get 5mb random data
+    /// let mut msg = Message::new(get_random_bytes(5242880));
+    /// // Create a new private/public keypair
+    /// let key_pair = KeyPair::new(&get_random_bytes(32), "test key".to_string(), &SecParam::D512).expect("Failed to create key pair");
+    ///
+    /// // Encrypt the message
+    /// msg.key_encrypt(&key_pair.pub_key, &SecParam::D512);
+    //  Decrypt the message
+    /// msg.key_decrypt(&key_pair.priv_key);
+    /// // Verify successful operation
+    /// msg.op_result.expect("Asymmetric decryption failed");    
+    /// ```
+    #[allow(non_snake_case)]
+    pub fn new(pw: &[u8], owner: String, d: &SecParam) -> Result<KeyPair, OperationError> {
+        let data = kmac_xof(pw, &[], 448, "SK", d)?;
+        let s: Scalar = bytes_to_scalar(data).mul_mod(&Scalar::from(4_u64));
+        let V = ExtendedPoint::generator() * s;
+        Ok(KeyPair {
+            owner,
+            pub_key: V,
+            priv_key: pw.to_vec(),
+            date_created: get_date_and_time_as_string(),
+        })
+    }
+
+    /// # KeyPair Saving
+    ///
+    /// Saves the key pair to a JSON file.
+    ///
+    /// ## Usage:
+    ///
+    /// ```rust
+    /// use capycrypt::KeyPair;
+    /// use capycrypt::SecParam;
+    ///
+    /// let key_pair = KeyPair::new("password".as_bytes(), "owner".to_string(), &SecParam::D512)
+    ///     .expect("Failed to create key pair");
+    ///
+    /// // key_pair.write_to_file("keypai1r.json").expect("Failed to save key pair");
+    pub fn write_to_file(&self, filename: &str) -> std::io::Result<()> {
+        let json_key_pair = serde_json::to_string_pretty(self).unwrap();
+        std::fs::write(filename, json_key_pair)
+    }
+
+    /// # KeyPair Loading
+    ///
+    /// Reads a JSON file and creates a `KeyPair` from its contents.
+    ///
+    /// ## Errors:
+    ///
+    /// Returns an error if:
+    /// - The file cannot be opened or read.
+    /// - The JSON content cannot be parsed into a `KeyPair`.
+    ///
+    /// ## Usage:
+    ///
+    /// ```rust
+    /// use capycrypt::KeyPair;
+    ///
+    /// // Assuming "keypair.json" contains a serialized KeyPair
+    /// match KeyPair::read_from_file("keypair.json") {
+    ///     Ok(key_pair) => {
+    ///         println!("Loaded KeyPair: {:?}", key_pair);
+    ///     },
+    ///     Err(err) => eprintln!("Error loading KeyPair: {}", err),
+    /// }
+    /// ```
+    pub fn read_from_file(filename: &str) -> Result<KeyPair, Box<dyn std::error::Error>> {
+        let mut file = File::open(filename)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+
+        let keypair: KeyPair = serde_json::from_str(&contents)?;
+        Ok(keypair)
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 /// Message struct for which cryptographic traits are defined.
 pub struct Message {
@@ -86,6 +194,35 @@ pub struct Message {
     pub op_result: Result<(), OperationError>,
     /// Schnorr signatures on the input message
     pub sig: Option<Signature>,
+}
+
+impl Message {
+    /// Returns a new Message instance
+    pub fn new(data: Vec<u8>) -> Message {
+        Message {
+            msg: Box::new(data),
+            d: None,
+            sym_nonce: None,
+            asym_nonce: None,
+            digest: Ok(vec![]),
+            op_result: Ok(()),
+            sig: None,
+        }
+    }
+
+    pub fn write_to_file(&self, filename: &str) -> std::io::Result<()> {
+        let json_key_pair = serde_json::to_string(self).unwrap();
+        std::fs::write(filename, json_key_pair)
+    }
+
+    pub fn read_from_file(filename: &str) -> Result<Message, Box<dyn std::error::Error>> {
+        let mut file = File::open(filename)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+
+        let message: Message = serde_json::from_str(&contents)?;
+        Ok(message)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ impl Message {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 /// An enum representing standard digest lengths based on FIPS PUB 202
 pub enum SecParam {
     /// Digest length of 224 bits, also known as SHA3-224
@@ -114,6 +114,39 @@ pub enum SecParam {
 }
 
 impl SecParam {
+
+    /// Convert an integer input to the corresponding security parameter.
+    /// # Arguments
+    ///
+    /// * `value` - An integer representing the desired security parameter.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(SecParam)` - If the conversion is successful, returns the corresponding `SecParam`.
+    /// * `Err(OperationError)` - If the given `value` does not correspond to any supported security parameter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use capycrypt::SecParam;
+    /// use capycrypt::OperationError;
+    ///
+    /// assert_eq!(SecParam::from_int(224).unwrap(), SecParam::D224);
+    /// assert_eq!(SecParam::from_int(256).unwrap(), SecParam::D256);
+    /// assert_eq!(SecParam::from_int(384).unwrap(), SecParam::D384);
+    /// assert_eq!(SecParam::from_int(512).unwrap(), SecParam::D512);
+    /// assert_eq!(SecParam::from_int(1024), Err(OperationError::UnsupportedSecurityParameter))
+    /// ``` 
+    pub fn from_int(value: usize) -> Result<SecParam, OperationError> {
+        match value {
+            224 => Ok(SecParam::D224),
+            256 => Ok(SecParam::D256),
+            384 => Ok(SecParam::D384),
+            512 => Ok(SecParam::D512),
+            _ => Err(OperationError::UnsupportedSecurityParameter),
+        }
+    }
+
     fn bytepad_value(&self) -> u32 {
         match self {
             SecParam::D224 => 172,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,6 @@ pub enum SecParam {
 }
 
 impl SecParam {
-
     /// Convert an integer input to the corresponding security parameter.
     /// # Arguments
     ///
@@ -136,7 +135,7 @@ impl SecParam {
     /// assert_eq!(SecParam::from_int(384).unwrap(), SecParam::D384);
     /// assert_eq!(SecParam::from_int(512).unwrap(), SecParam::D512);
     /// assert_eq!(SecParam::from_int(1024), Err(OperationError::UnsupportedSecurityParameter))
-    /// ``` 
+    /// ```
     pub fn from_int(value: usize) -> Result<SecParam, OperationError> {
         match value {
             224 => Ok(SecParam::D224),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 /// Elliptic curve backend
 use tiny_ed448_goldilocks::curve::{extended_edwards::ExtendedPoint, field::scalar::Scalar};
 
+/// Serializing data structures
+use serde::Serialize;
+
 /// Module for SHA-3 primitives
 pub mod sha3 {
 
@@ -53,7 +56,7 @@ pub struct Signature {
     pub z: Scalar,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Serialize, Debug, Clone)]
 /// An object containing the fields necessary to represent an asymmetric keypair.
 pub struct KeyPair {
     /// String indicating the owner of the key, can be arbitrary

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 use tiny_ed448_goldilocks::curve::{extended_edwards::ExtendedPoint, field::scalar::Scalar};
 
 /// Serializing data structures
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Module for SHA-3 primitives
 pub mod sha3 {
@@ -56,7 +56,7 @@ pub struct Signature {
     pub z: Scalar,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 /// An object containing the fields necessary to represent an asymmetric keypair.
 pub struct KeyPair {
     /// String indicating the owner of the key, can be arbitrary
@@ -117,28 +117,8 @@ pub enum SecParam {
 }
 
 impl SecParam {
-    /// Convert an integer input to the corresponding security parameter.
-    /// # Arguments
-    ///
-    /// * `value` - An integer representing the desired security parameter.
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(SecParam)` - If the conversion is successful, returns the corresponding `SecParam`.
-    /// * `Err(OperationError)` - If the given `value` does not correspond to any supported security parameter.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use capycrypt::SecParam;
-    /// use capycrypt::OperationError;
-    ///
-    /// assert_eq!(SecParam::from_int(224).unwrap(), SecParam::D224);
-    /// assert_eq!(SecParam::from_int(256).unwrap(), SecParam::D256);
-    /// assert_eq!(SecParam::from_int(384).unwrap(), SecParam::D384);
-    /// assert_eq!(SecParam::from_int(512).unwrap(), SecParam::D512);
-    /// assert_eq!(SecParam::from_int(1024), Err(OperationError::UnsupportedSecurityParameter))
-    /// ```
+    /// Converts an integer input to the corresponding security parameter.
+    /// Supports security levels of 224, 256, 384, and 512 bits.
     pub fn from_int(value: usize) -> Result<SecParam, OperationError> {
         match value {
             224 => Ok(SecParam::D224),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(
     name = "capycrypt-cli",
-    about = "Support command-line interface for capyCrypt library"
+    about = "Command-line interface for capycrypt library"
 )]
 enum Command {
     #[structopt(name = "sha3")]
@@ -67,7 +67,7 @@ fn main() {
             let kp = KeyPair::new(pw.as_bytes(), owner, &sec_param)
                 .expect("Unable to generate the requested key pair");
 
-            let _ = kp.save_to_file(&output);
+            let _ = kp.write_to_file(&output);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use capycrypt::{Hashable, Message, SecParam};
+use capycrypt::{Hashable, KeyPair, Message, SecParam};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -20,6 +20,24 @@ enum Command {
         )]
         bits: usize,
     },
+
+    #[structopt(name = "new_keypair")]
+    NewKeypair {
+        #[structopt(help = "Password")]
+        pw: String,
+
+        #[structopt(help = "Owner of the key pair")]
+        owner: String,
+
+        #[structopt(help = "Selected curve")]
+        _curve: String,
+
+        #[structopt(help = "Security length", short, long, default_value = "256")]
+        bits: usize,
+
+        #[structopt(help = "Output file name", short, long)]
+        output: String,
+    },
 }
 
 fn main() {
@@ -36,6 +54,20 @@ fn main() {
                 Ok(digest) => println!("Hash: {}", hex::encode(digest)),
                 Err(_) => eprintln!("Error: Hash computation failed"),
             }
+        }
+
+        Command::NewKeypair {
+            pw,
+            owner,
+            _curve,
+            bits,
+            output,
+        } => {
+            let sec_param = SecParam::from_int(bits).expect("Unsupported security parameter.");
+            let kp = KeyPair::new(pw.as_bytes(), owner, &sec_param)
+                .expect("Unable to generate the requested key pair");
+
+            let _ = kp.save_to_file(&output);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,12 @@ use capycrypt::{Hashable, Message, SecParam};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "capycrypt-cli", about = "A simple hashing CLI")]
+#[structopt(
+    name = "capycrypt-cli",
+    about = "Support command-line interface for capyCrypt library"
+)]
 enum Command {
-    //enums and structs in rust can be used almost interchangeably.
-    #[structopt(name = "compute_sha3_hash")] // the name of the program to run
+    #[structopt(name = "sha3")]
     Sha3 {
         #[structopt(help = "The input string to hash")]
         input: String,

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -344,6 +344,12 @@ impl KeyPair {
             date_created: get_date_and_time_as_string(),
         })
     }
+
+    /// Documentation should be written
+    pub fn save_to_file(&self, filename: &str) -> std::io::Result<()> {
+        let json_key_pair = serde_json::to_string_pretty(self).unwrap();
+        std::fs::write(filename, json_key_pair)
+    }
 }
 
 impl KeyEncryptable for Message {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -22,6 +22,8 @@ use crate::{
     RATE_IN_BYTES,
 };
 use rayon::prelude::*;
+use std::fs::File;
+use std::io::Read;
 use tiny_ed448_goldilocks::curve::{extended_edwards::ExtendedPoint, field::scalar::Scalar};
 
 /// # SHA3-Keccak
@@ -345,10 +347,57 @@ impl KeyPair {
         })
     }
 
-    /// Documentation should be written
-    pub fn save_to_file(&self, filename: &str) -> std::io::Result<()> {
+    /// # KeyPair Saving
+    ///
+    /// Saves the key pair to a JSON file.
+    ///
+    /// ## Usage:
+    ///
+    /// ```rust
+    /// use capycrypt::KeyPair;
+    /// use capycrypt::SecParam;
+    ///
+    /// let key_pair = KeyPair::new("password".as_bytes(), "owner".to_string(), &SecParam::D512)
+    ///     .expect("Failed to create key pair");
+    ///
+    /// // key_pair.write_to_file("keypai1r.json").expect("Failed to save key pair");
+    pub fn write_to_file(&self, filename: &str) -> std::io::Result<()> {
         let json_key_pair = serde_json::to_string_pretty(self).unwrap();
         std::fs::write(filename, json_key_pair)
+    }
+
+    /// # KeyPair Loading
+    ///
+    /// Reads a JSON file and creates a `KeyPair` from its contents.
+    ///
+    /// ## Errors:
+    ///
+    /// Returns an error if:
+    /// - The file cannot be opened or read.
+    /// - The JSON content cannot be parsed into a `KeyPair`.
+    ///
+    /// ## Usage:
+    ///
+    /// ```rust
+    /// use capycrypt::KeyPair;
+    ///
+    /// // Assuming "keypair.json" contains a serialized KeyPair
+    /// match KeyPair::read_from_file("keypair.json") {
+    ///     Ok(key_pair) => {
+    ///         println!("Loaded KeyPair: {:?}", key_pair);
+    ///         // Additional processing with the loaded KeyPair
+    ///     },
+    ///     Err(err) => eprintln!("Error loading KeyPair: {}", err),
+    /// }
+    /// ```
+    pub fn read_from_file(filename: &str) -> Result<KeyPair, Box<dyn std::error::Error>> {
+        let mut file = File::open(filename)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+
+        // Parse the JSON string into a MyData struct
+        let keypair: KeyPair = serde_json::from_str(&contents)?;
+        Ok(keypair)
     }
 }
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -9,10 +9,7 @@ use crate::{
     aes::aes_functions::{apply_pcks7_padding, remove_pcks7_padding, xor_blocks, AES},
     sha3::{
         aux_functions::{
-            byte_utils::{
-                bytes_to_scalar, get_date_and_time_as_string, get_random_bytes, scalar_to_bytes,
-                xor_bytes,
-            },
+            byte_utils::{bytes_to_scalar, get_random_bytes, scalar_to_bytes, xor_bytes},
             nist_800_185::{byte_pad, encode_string, right_encode},
         },
         sponge::{sponge_absorb, sponge_squeeze},
@@ -22,8 +19,6 @@ use crate::{
     RATE_IN_BYTES,
 };
 use rayon::prelude::*;
-use std::fs::File;
-use std::io::Read;
 use tiny_ed448_goldilocks::curve::{extended_edwards::ExtendedPoint, field::scalar::Scalar};
 
 /// # SHA3-Keccak
@@ -293,138 +288,6 @@ impl SpongeEncryptable for Message {
         };
 
         Ok(())
-    }
-}
-
-impl KeyPair {
-    /// # Asymmetric [`KeyPair`] Generation
-    /// Generates a (Schnorr/ECDHIES) key pair from passphrase pw.
-    ///
-    /// ## Algorithm:
-    /// * s ← kmac_xof(pw, “”, 448, “K”); s ← 4s
-    /// * 𝑉 ← s*𝑮
-    /// * key pair: (s, 𝑉)
-    /// ## Arguments:
-    /// * pw: &Vec<u8> : password as bytes, can be blank but shouldnt be
-    /// * owner: String : A label to indicate the owner of the key
-    /// * curve: [`EdCurves`] : The selected Edwards curve
-    /// ## Returns:
-    /// * return  -> [`KeyPair`]: Key object containing owner, private key, public key x and y coordinates, and timestamp.
-    /// verification key 𝑉 is hashed together with the message 𝑚
-    /// and the nonce 𝑈: hash (𝑚, 𝑈, 𝑉) .
-    /// ## Usage:
-    /// ```
-    /// use capycrypt::{
-    ///     KeyEncryptable,
-    ///     KeyPair,
-    ///     Message,
-    ///     sha3::aux_functions::byte_utils::get_random_bytes,
-    ///     SecParam,
-    /// };
-    ///
-    /// // Get 5mb random data
-    /// let mut msg = Message::new(get_random_bytes(5242880));
-    /// // Create a new private/public keypair
-    /// let key_pair = KeyPair::new(&get_random_bytes(32), "test key".to_string(), &SecParam::D512).expect("Failed to create key pair");
-    ///
-    /// // Encrypt the message
-    /// msg.key_encrypt(&key_pair.pub_key, &SecParam::D512);
-    //  Decrypt the message
-    /// msg.key_decrypt(&key_pair.priv_key);
-    /// // Verify successful operation
-    /// msg.op_result.expect("Asymmetric decryption failed");    
-    /// ```
-    #[allow(non_snake_case)]
-    pub fn new(pw: &[u8], owner: String, d: &SecParam) -> Result<KeyPair, OperationError> {
-        let data = kmac_xof(pw, &[], 448, "SK", d)?;
-        let s: Scalar = bytes_to_scalar(data).mul_mod(&Scalar::from(4_u64));
-        let V = ExtendedPoint::generator() * s;
-        Ok(KeyPair {
-            owner,
-            pub_key: V,
-            priv_key: pw.to_vec(),
-            date_created: get_date_and_time_as_string(),
-        })
-    }
-
-    /// # KeyPair Saving
-    ///
-    /// Saves the key pair to a JSON file.
-    ///
-    /// ## Usage:
-    ///
-    /// ```rust
-    /// use capycrypt::KeyPair;
-    /// use capycrypt::SecParam;
-    ///
-    /// let key_pair = KeyPair::new("password".as_bytes(), "owner".to_string(), &SecParam::D512)
-    ///     .expect("Failed to create key pair");
-    ///
-    /// // key_pair.write_to_file("keypai1r.json").expect("Failed to save key pair");
-    pub fn write_to_file(&self, filename: &str) -> std::io::Result<()> {
-        let json_key_pair = serde_json::to_string_pretty(self).unwrap();
-        std::fs::write(filename, json_key_pair)
-    }
-
-    /// # KeyPair Loading
-    ///
-    /// Reads a JSON file and creates a `KeyPair` from its contents.
-    ///
-    /// ## Errors:
-    ///
-    /// Returns an error if:
-    /// - The file cannot be opened or read.
-    /// - The JSON content cannot be parsed into a `KeyPair`.
-    ///
-    /// ## Usage:
-    ///
-    /// ```rust
-    /// use capycrypt::KeyPair;
-    ///
-    /// // Assuming "keypair.json" contains a serialized KeyPair
-    /// match KeyPair::read_from_file("keypair.json") {
-    ///     Ok(key_pair) => {
-    ///         println!("Loaded KeyPair: {:?}", key_pair);
-    ///     },
-    ///     Err(err) => eprintln!("Error loading KeyPair: {}", err),
-    /// }
-    /// ```
-    pub fn read_from_file(filename: &str) -> Result<KeyPair, Box<dyn std::error::Error>> {
-        let mut file = File::open(filename)?;
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
-
-        let keypair: KeyPair = serde_json::from_str(&contents)?;
-        Ok(keypair)
-    }
-}
-
-impl Message {
-    /// Returns a new Message instance
-    pub fn new(data: Vec<u8>) -> Message {
-        Message {
-            msg: Box::new(data),
-            d: None,
-            sym_nonce: None,
-            asym_nonce: None,
-            digest: Ok(vec![]),
-            op_result: Ok(()),
-            sig: None,
-        }
-    }
-
-    pub fn write_to_file(&self, filename: &str) -> std::io::Result<()> {
-        let json_key_pair = serde_json::to_string(self).unwrap();
-        std::fs::write(filename, json_key_pair)
-    }
-
-    pub fn read_from_file(filename: &str) -> Result<Message, Box<dyn std::error::Error>> {
-        let mut file = File::open(filename)?;
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
-
-        let message: Message = serde_json::from_str(&contents)?;
-        Ok(message)
     }
 }
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -385,7 +385,6 @@ impl KeyPair {
     /// match KeyPair::read_from_file("keypair.json") {
     ///     Ok(key_pair) => {
     ///         println!("Loaded KeyPair: {:?}", key_pair);
-    ///         // Additional processing with the loaded KeyPair
     ///     },
     ///     Err(err) => eprintln!("Error loading KeyPair: {}", err),
     /// }
@@ -395,9 +394,37 @@ impl KeyPair {
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
 
-        // Parse the JSON string into a MyData struct
         let keypair: KeyPair = serde_json::from_str(&contents)?;
         Ok(keypair)
+    }
+}
+
+impl Message {
+    /// Returns a new Message instance
+    pub fn new(data: Vec<u8>) -> Message {
+        Message {
+            msg: Box::new(data),
+            d: None,
+            sym_nonce: None,
+            asym_nonce: None,
+            digest: Ok(vec![]),
+            op_result: Ok(()),
+            sig: None,
+        }
+    }
+
+    pub fn write_to_file(&self, filename: &str) -> std::io::Result<()> {
+        let json_key_pair = serde_json::to_string(self).unwrap();
+        std::fs::write(filename, json_key_pair)
+    }
+
+    pub fn read_from_file(filename: &str) -> Result<Message, Box<dyn std::error::Error>> {
+        let mut file = File::open(filename)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+
+        let message: Message = serde_json::from_str(&contents)?;
+        Ok(message)
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -141,4 +141,30 @@ pub mod ops_tests {
         assert!(msg.verify(&read_key_pair.pub_key).is_ok());
         assert!(msg.op_result.is_ok());
     }
+
+    #[test]
+    pub fn test_signature_512_read_message_from_file() {
+        let temp_dir = tempdir().expect("Failed to create temporary directory");
+        let temp_file_path: std::path::PathBuf = temp_dir.path().join("temp_message.json");
+        let _ = Message::new(get_random_bytes(5242880))
+            .write_to_file(temp_file_path.to_str().unwrap())
+            .unwrap();
+
+        let mut initial_msg = Message::read_from_file(temp_file_path.to_str().unwrap()).unwrap();
+
+        let pw = get_random_bytes(64);
+        let key_pair = KeyPair::new(&pw, "test key".to_string(), &SecParam::D512).unwrap();
+
+        assert!(initial_msg.sign(&key_pair, &SecParam::D512).is_ok());
+
+        let _ = initial_msg
+            .write_to_file(temp_file_path.to_str().unwrap())
+            .unwrap();
+
+        let mut signed_msg = Message::read_from_file(temp_file_path.to_str().unwrap()).unwrap();
+
+        assert!(signed_msg.verify(&key_pair.pub_key).is_ok());
+
+        assert!(signed_msg.op_result.is_ok());
+    }
 }


### PR DESCRIPTION
This pull request addresses the following issues:

- Implemented `save_to_file` functionality for KeyPair.
- Added corresponding CLI support.

To execute the command, use the following syntax:
`capycrypt new_keypair "pw" "owner" -b 256 --output "output.json"`

Note: **The curve input has been excluded for now as it is not part of the KeyPair::new() method.**

