### PR TITLE
Fix/issue 18

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ pub trait Signable {
 
 pub trait UpdateFinalize {
     fn update(&mut self, data: &[u8]);
-    fn finalize(&mut self) -> Result<(), OperationError>;
+    fn finalize(&mut self, output_length: u64) -> Result<(), OperationError>;
 }
 const RATE_IN_BYTES: usize = 136; // SHA3-256 r = 1088 / 8 = 136
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,10 @@ pub trait Signable {
     fn verify(&mut self, pub_key: &ExtendedPoint) -> Result<(), OperationError>;
 }
 
+pub trait UpdateFinalize {
+    fn update(&mut self, data: &[u8]);
+    fn finalize(&mut self) -> Result<(), OperationError>;
+}
 const RATE_IN_BYTES: usize = 136; // SHA3-256 r = 1088 / 8 = 136
 
 #[cfg(test)]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -903,8 +903,9 @@ impl UpdateFinalize for Message {
 
         match self.d {
             Some(d) => self.compute_hash_sha3(&d),
-            None => Err(OperationError::UnsupportedSecurityParameter)
+            None => Err(OperationError::UnsupportedSecurityParameter)        
         } 
+        
     }
 }
 ///
@@ -1191,7 +1192,7 @@ mod shake_tests {
 }
 
 #[cfg(test)]
-mod updateFinalize_tests {
+mod update_finalize_tests {
     use crate::{ops::UpdateFinalize, Hashable, Message, SecParam::D256};
     #[test]
     fn test_updated_message_256() {
@@ -1202,9 +1203,7 @@ mod updateFinalize_tests {
         m.update(b"baz");
 
         let mut expected = Message::new(b"foobarbaz".to_vec());
-        expected.compute_hash_sha3(&D256);
 
-        m.finalize();
-        assert_eq!(m.finalize(), expected);
+        assert_eq!(m.finalize(), expected.compute_hash_sha3(&D256));
     }
 }


### PR DESCRIPTION
As noted in a previous pull request #55, `fn finalize `has been updated with a single parameter, output_length.

Avoided using `clone()` inside the function.

Updating the multiple chunks of message generated a finalized hash code that matches the hash code of the original message.